### PR TITLE
Use log from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ keywords = ["protocol", "serialization"]
 
 name = "capnp"
 path = "src/capnp/lib.rs"
+
+[dependencies]
+log = "0.1"


### PR DESCRIPTION
In-tree `log` was deprecated a long ago and now almost all crates from
crates.io are linked against external log. Building capnproto-rust in 
this conditions is always a pain as rustc complains about 
linking to 2 different logs