### PR TITLE
Use PhantomData and PhantomFn everywhere necessary to compile with latest Rust

### DIFF
--- a/src/capability.rs
+++ b/src/capability.rs
@@ -28,29 +28,33 @@ use traits::{FromPointerReader, FromPointerBuilder};
 use private::capability::{CallContextHook, ClientHook, RequestHook, ResponseHook};
 
 pub struct ResultFuture<Results, Pipeline> {
+    pub marker : ::std::marker::PhantomData<Results>,
     pub answer_port : ::std::sync::mpsc::Receiver<Box<ResponseHook+Send>>,
     pub answer_result : Result<Box<ResponseHook+Send>, ()>,
     pub pipeline : Pipeline,
 }
 
 pub struct Request<Params, Results, Pipeline> {
+    pub marker : ::std::marker::PhantomData<(Params, Results, Pipeline)>,
     pub hook : Box<RequestHook+Send>
 }
 
 impl <Params, Results, Pipeline > Request <Params, Results, Pipeline> {
     pub fn new(hook : Box<RequestHook+Send>) -> Request <Params, Results, Pipeline> {
-        Request { hook : hook }
+        Request { hook : hook, marker: ::std::marker::PhantomData }
     }
 }
 impl <Params, Results, Pipeline : FromTypelessPipeline> Request <Params, Results, Pipeline> {
     pub fn send(self) -> ResultFuture<Results, Pipeline> {
-        let ResultFuture {answer_port, answer_result, pipeline} = self.hook.send();
+        let ResultFuture {answer_port, answer_result, pipeline, ..} = self.hook.send();
         ResultFuture { answer_port : answer_port, answer_result : answer_result,
-                        pipeline : FromTypelessPipeline::new(pipeline) }
+                        pipeline : FromTypelessPipeline::new(pipeline),
+                        marker : ::std::marker::PhantomData }
     }
 }
 
 pub struct CallContext<Params, Results> {
+    pub marker : ::std::marker::PhantomData<(Params, Results)>,
     pub hook : Box<CallContextHook+Send>,
 }
 

--- a/src/enum_list.rs
+++ b/src/enum_list.rs
@@ -27,12 +27,13 @@ use private::layout::{ListReader, ListBuilder, PointerReader, PointerBuilder,
 
 #[derive(Copy)]
 pub struct Reader<'a, T> {
+    marker : ::std::marker::PhantomData<T>,
     reader : ListReader<'a>
 }
 
 impl <'a, T : ::std::num::FromPrimitive> Reader<'a, T> {
     pub fn new<'b>(reader : ListReader<'b>) -> Reader<'b, T> {
-        Reader::<'b, T> { reader : reader }
+        Reader::<'b, T> { reader : reader, marker : ::std::marker::PhantomData }
     }
 
     pub fn len(&self) -> u32 { self.reader.len() }
@@ -41,7 +42,8 @@ impl <'a, T : ::std::num::FromPrimitive> Reader<'a, T> {
 
 impl <'a, T : ::std::num::FromPrimitive> FromPointerReader<'a> for Reader<'a, T> {
     fn get_from_pointer(reader : &PointerReader<'a>) -> Reader<'a, T> {
-        Reader { reader : reader.get_list(TwoBytes, ::std::ptr::null()) }
+        Reader { reader : reader.get_list(TwoBytes, ::std::ptr::null()),
+                 marker : ::std::marker::PhantomData }
     }
 }
 
@@ -54,12 +56,13 @@ impl <'a, T : ::std::num::FromPrimitive> Reader<'a, T> {
 }
 
 pub struct Builder<'a, T> {
+    marker : ::std::marker::PhantomData<T>,
     builder : ListBuilder<'a>
 }
 
 impl <'a, T : ToU16 + ::std::num::FromPrimitive> Builder<'a, T> {
     pub fn new(builder : ListBuilder<'a>) -> Builder<'a, T> {
-        Builder { builder : builder }
+        Builder { builder : builder, marker : ::std::marker::PhantomData }
     }
 
     pub fn len(&self) -> u32 { self.builder.len() }
@@ -72,10 +75,12 @@ impl <'a, T : ToU16 + ::std::num::FromPrimitive> Builder<'a, T> {
 
 impl <'a, T : ::std::num::FromPrimitive> FromPointerBuilder<'a> for Builder<'a, T> {
     fn init_pointer(builder : PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
-        Builder { builder : builder.init_list(TwoBytes, size) }
+        Builder { builder : builder.init_list(TwoBytes, size),
+                  marker : ::std::marker::PhantomData }
     }
     fn get_from_pointer(builder : PointerBuilder<'a>) -> Builder<'a, T> {
-        Builder { builder : builder.get_list(TwoBytes, ::std::ptr::null()) }
+        Builder { builder : builder.get_list(TwoBytes, ::std::ptr::null()),
+                  marker : ::std::marker::PhantomData }
     }
 }
 
@@ -95,7 +100,7 @@ impl <'a, T> ::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T> {
 
 impl <'a, 'b : 'a, T> ::traits::CastableTo<Builder<'a, T> > for Builder<'b, T> {
     fn cast(self) -> Builder<'a, T> {
-        Builder { builder : self.builder }
+        Builder { builder : self.builder, marker : ::std::marker::PhantomData }
     }
 }
 

--- a/src/list_list.rs
+++ b/src/list_list.rs
@@ -26,12 +26,13 @@ use private::layout::{ListReader, ListBuilder, PointerReader, PointerBuilder, Po
 
 #[derive(Copy)]
 pub struct Reader<'a, T> {
+    marker : ::std::marker::PhantomData<T>,
     reader : ListReader<'a>
 }
 
 impl <'a, T> Reader<'a, T> {
     pub fn new<'b>(reader : ListReader<'b>) -> Reader<'b, T> {
-        Reader::<'b, T> { reader : reader }
+        Reader::<'b, T> { reader : reader, marker : ::std::marker::PhantomData }
     }
 
     pub fn len(&self) -> u32 { self.reader.len() }
@@ -39,7 +40,8 @@ impl <'a, T> Reader<'a, T> {
 
 impl <'a, T : FromPointerReader<'a>> FromPointerReader<'a> for Reader<'a, T> {
     fn get_from_pointer(reader : &PointerReader<'a>) -> Reader<'a, T> {
-        Reader { reader : reader.get_list(Pointer, ::std::ptr::null()) }
+        Reader { reader : reader.get_list(Pointer, ::std::ptr::null()),
+                 marker : ::std::marker::PhantomData }
     }
 }
 
@@ -51,12 +53,13 @@ impl <'a, T : FromPointerReader<'a>> Reader<'a, T> {
 }
 
 pub struct Builder<'a, T> {
+    marker : ::std::marker::PhantomData<T>,
     builder : ListBuilder<'a>
 }
 
 impl <'a, T : FromPointerBuilder<'a>> Builder<'a, T> {
     pub fn new(builder : ListBuilder<'a>) -> Builder<'a, T> {
-        Builder { builder : builder }
+        Builder { builder : builder, marker : ::std::marker::PhantomData }
     }
 
     pub fn len(&self) -> u32 { self.builder.len() }
@@ -70,18 +73,20 @@ impl <'a, T : FromPointerBuilder<'a>> Builder<'a, T> {
 
 impl <'a, T> Builder<'a, T> {
     pub fn borrow<'b, U>(&'b mut self) -> Builder<'b, U> where T : ::traits::CastableTo<U> {
-        Builder {builder : self.builder}
+        Builder {builder : self.builder, marker : ::std::marker::PhantomData}
     }
 }
 
 impl <'a, T : FromPointerBuilder<'a>> FromPointerBuilder<'a> for Builder<'a, T> {
     fn init_pointer(builder : PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
         Builder {
+            marker : ::std::marker::PhantomData,
             builder : builder.init_list(Pointer, size)
         }
     }
     fn get_from_pointer(builder : PointerBuilder<'a>) -> Builder<'a, T> {
         Builder {
+            marker : ::std::marker::PhantomData,
             builder : builder.get_list(Pointer, ::std::ptr::null())
         }
     }
@@ -102,6 +107,6 @@ impl <'a, T> ::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T> {
 
 impl <'a, 'b : 'a, T, U : ::traits::CastableTo<T>> ::traits::CastableTo<Builder<'a, T> > for Builder<'b, U> {
     fn cast(self) -> Builder<'a, T> {
-        Builder { builder : self.builder }
+        Builder { builder : self.builder, marker : ::std::marker::PhantomData }
     }
 }

--- a/src/primitive_list.rs
+++ b/src/primitive_list.rs
@@ -27,12 +27,13 @@ use private::layout::{ListReader, ListBuilder, PointerReader, PointerBuilder,
 
 #[derive(Copy)]
 pub struct Reader<'a, T> {
+    marker : ::std::marker::PhantomData<T>,
     reader : ListReader<'a>
 }
 
 impl <'a, T : PrimitiveElement> Reader<'a, T> {
     pub fn new<'b>(reader : ListReader<'b>) -> Reader<'b, T> {
-        Reader::<'b, T> { reader : reader }
+        Reader::<'b, T> { reader : reader, marker : ::std::marker::PhantomData }
     }
 
     pub fn len(&self) -> u32 { self.reader.len() }
@@ -40,7 +41,8 @@ impl <'a, T : PrimitiveElement> Reader<'a, T> {
 
 impl <'a, T : PrimitiveElement> FromPointerReader<'a> for Reader<'a, T> {
     fn get_from_pointer(reader : &PointerReader<'a>) -> Reader<'a, T> {
-        Reader { reader : reader.get_list(element_size_for_type::<T>(), ::std::ptr::null()) }
+        Reader { reader : reader.get_list(element_size_for_type::<T>(), ::std::ptr::null()),
+                 marker : ::std::marker::PhantomData }
     }
 }
 
@@ -52,12 +54,13 @@ impl <'a, T : PrimitiveElement> Reader<'a, T> {
 }
 
 pub struct Builder<'a, T> {
+    marker : ::std::marker::PhantomData<T>,
     builder : ListBuilder<'a>
 }
 
 impl <'a, T : PrimitiveElement> Builder<'a, T> {
     pub fn new(builder : ListBuilder<'a>) -> Builder<'a, T> {
-        Builder { builder : builder }
+        Builder { builder : builder, marker : ::std::marker::PhantomData }
     }
 
     pub fn len(&self) -> u32 { self.builder.len() }
@@ -69,10 +72,12 @@ impl <'a, T : PrimitiveElement> Builder<'a, T> {
 
 impl <'a, T : PrimitiveElement> FromPointerBuilder<'a> for Builder<'a, T> {
     fn init_pointer(builder : PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
-        Builder { builder : builder.init_list(element_size_for_type::<T>(), size) }
+        Builder { builder : builder.init_list(element_size_for_type::<T>(), size),
+                  marker : ::std::marker::PhantomData }
     }
     fn get_from_pointer(builder : PointerBuilder<'a>) -> Builder<'a, T> {
-        Builder { builder : builder.get_list(element_size_for_type::<T>(), ::std::ptr::null())}
+        Builder { builder : builder.get_list(element_size_for_type::<T>(), ::std::ptr::null()),
+                  marker : ::std::marker::PhantomData }
     }
 }
 
@@ -91,6 +96,6 @@ impl <'a, T> ::traits::SetPointerBuilder<Builder<'a, T>> for Reader<'a, T> {
 
 impl <'a, 'b : 'a, T> ::traits::CastableTo<Builder<'a, T> > for Builder<'b, T> {
     fn cast(self) -> Builder<'a, T> {
-        Builder { builder : self.builder }
+        Builder { builder : self.builder, marker : ::std::marker::PhantomData }
     }
 }

--- a/src/private/capability.rs
+++ b/src/private/capability.rs
@@ -66,7 +66,7 @@ impl Client {
                                                size_hint : Option<MessageSize>)
                                                -> Request<Params, Results, Pipeline> {
         let typeless = self.hook.new_call(interface_id, method_id, size_hint);
-        Request { hook : typeless.hook }
+        Request { hook : typeless.hook, marker : ::std::marker::PhantomData }
     }
 }
 
@@ -80,7 +80,7 @@ pub trait CallContextHook {
 pub fn internal_get_typed_context<Params, Results>(
     typeless : CallContext<any_pointer::Reader, any_pointer::Builder>)
     -> CallContext<Params, Results> {
-    CallContext { hook : typeless.hook }
+    CallContext { hook : typeless.hook, marker : ::std::marker::PhantomData }
 }
 
 

--- a/src/private/layout.rs
+++ b/src/private/layout.rs
@@ -809,7 +809,7 @@ mod wire_helpers {
         (*reff).mut_struct_ref().set_from_struct_size(size);
 
         StructBuilder {
-            marker : ::std::marker::ContravariantLifetime::<'a>,
+            marker : ::std::marker::PhantomData::<&'a ()>,
             segment : segment_builder,
             data : ::std::mem::transmute(ptr),
             pointers : ::std::mem::transmute(
@@ -883,7 +883,7 @@ mod wire_helpers {
                 ::std::ptr::zero_memory(old_ptr, old_data_size as usize + old_pointer_count as usize);
 
                 return StructBuilder {
-                    marker : ::std::marker::ContravariantLifetime::<'a>,
+                    marker : ::std::marker::PhantomData::<&'a ()>,
                     segment : segment,
                     data : ::std::mem::transmute(ptr),
                     pointers : new_pointer_section,
@@ -892,7 +892,7 @@ mod wire_helpers {
                 };
             } else {
                 return StructBuilder {
-                    marker : ::std::marker::ContravariantLifetime::<'a>,
+                    marker : ::std::marker::PhantomData::<&'a ()>,
                     segment : old_segment,
                     data : ::std::mem::transmute(old_ptr),
                     pointers : old_pointer_section,
@@ -920,7 +920,7 @@ mod wire_helpers {
         (*reff).mut_list_ref().set(element_size, element_count);
 
         ListBuilder {
-            marker : ::std::marker::ContravariantLifetime::<'a>,
+            marker : ::std::marker::PhantomData::<&'a ()>,
             segment : segment_builder,
             ptr : ::std::mem::transmute(ptr),
             step : step,
@@ -951,7 +951,7 @@ mod wire_helpers {
         let ptr1 = ptr.offset(POINTER_SIZE_IN_WORDS as isize);
 
         ListBuilder {
-            marker : ::std::marker::ContravariantLifetime::<'a>,
+            marker : ::std::marker::PhantomData::<&'a ()>,
             segment : segment_builder,
             ptr : ::std::mem::transmute(ptr1),
             step : words_per_element * BITS_PER_WORD as u32,
@@ -1044,7 +1044,7 @@ mod wire_helpers {
                 //# OK, looks valid.
 
                 return ListBuilder {
-                    marker : ::std::marker::ContravariantLifetime::<'a>,
+                    marker : ::std::marker::PhantomData::<&'a ()>,
                     segment : segment,
                     ptr : ::std::mem::transmute(ptr),
                     element_count : (*tag).inline_composite_list_element_count(),
@@ -1068,7 +1068,7 @@ mod wire_helpers {
                 let step = data_size + pointer_count * BITS_PER_POINTER as u32;
 
                 return ListBuilder {
-                    marker : ::std::marker::ContravariantLifetime::<'a>,
+                    marker : ::std::marker::PhantomData::<&'a ()>,
                     segment : segment,
                     ptr : ::std::mem::transmute(ptr),
                     step : step,
@@ -1129,7 +1129,7 @@ mod wire_helpers {
                 if old_data_size >= element_size.data && old_pointer_count >= element_size.pointers {
                     //# Old size is at least as large as we need. Ship it.
                     return ListBuilder {
-                        marker : ::std::marker::ContravariantLifetime::<'a>,
+                        marker : ::std::marker::PhantomData::<&'a ()>,
                         segment : old_segment,
                         ptr : ::std::mem::transmute(old_ptr),
                         element_count : element_count,
@@ -1411,7 +1411,7 @@ mod wire_helpers {
                 return set_struct_pointer(
                     dst_segment, dst,
                     StructReader {
-                        marker : ::std::marker::ContravariantLifetime,
+                        marker : ::std::marker::PhantomData,
                         segment : src_segment,
                         data : ::std::mem::transmute(ptr),
                         pointers : ::std::mem::transmute(ptr.offset((*src).struct_ref().data_size.get() as isize)),
@@ -1451,7 +1451,7 @@ mod wire_helpers {
                     return set_list_pointer(
                         dst_segment, dst,
                         ListReader {
-                            marker : ::std::marker::ContravariantLifetime,
+                            marker : ::std::marker::PhantomData,
                             segment : src_segment,
                             ptr : ::std::mem::transmute(ptr),
                             element_count : element_count,
@@ -1475,7 +1475,7 @@ mod wire_helpers {
                     return set_list_pointer(
                         dst_segment, dst,
                         ListReader {
-                            marker : ::std::marker::ContravariantLifetime,
+                            marker : ::std::marker::PhantomData,
                             segment : src_segment,
                             ptr : ::std::mem::transmute(ptr),
                             element_count : element_count,
@@ -1545,7 +1545,7 @@ mod wire_helpers {
                      continue 'use_default);
 
             return StructReader {
-                marker : ::std::marker::ContravariantLifetime::<'a>,
+                marker : ::std::marker::PhantomData::<&'a ()>,
                 segment : segment,
                 data : ::std::mem::transmute(ptr),
                 pointers : ::std::mem::transmute(ptr.offset(data_size_words as isize)),
@@ -1660,7 +1660,7 @@ mod wire_helpers {
                     }
 
                     return ListReader {
-                        marker : ::std::marker::ContravariantLifetime::<'a>,
+                        marker : ::std::marker::PhantomData::<&'a ()>,
                         segment : segment,
                         ptr : ::std::mem::transmute(ptr),
                         element_count : size,
@@ -1711,7 +1711,7 @@ mod wire_helpers {
                              continue 'use_default);
 
                     return ListReader {
-                        marker : ::std::marker::ContravariantLifetime::<'a>,
+                        marker : ::std::marker::PhantomData::<&'a ()>,
                         segment : segment,
                         ptr : ::std::mem::transmute(ptr),
                         element_count : list_ref.element_count(),
@@ -1826,7 +1826,7 @@ fn zero_pointer() -> *const WirePointer { unsafe {::std::mem::transmute(&ZERO)}}
 
 #[derive(Copy)]
 pub struct PointerReader<'a> {
-    marker : ::std::marker::ContravariantLifetime<'a>,
+    marker : ::std::marker::PhantomData<&'a ()>,
     segment : *const SegmentReader,
     pointer : *const WirePointer,
     nesting_limit : i32
@@ -1835,7 +1835,7 @@ pub struct PointerReader<'a> {
 impl <'a> PointerReader<'a> {
     pub fn new_default<'b>() -> PointerReader<'b> {
         PointerReader {
-            marker : ::std::marker::ContravariantLifetime::<'a>,
+            marker : ::std::marker::PhantomData::<&'b ()>,
             segment : ::std::ptr::null(),
             pointer : ::std::ptr::null(),
             nesting_limit : 0x7fffffff }
@@ -1851,7 +1851,7 @@ impl <'a> PointerReader<'a> {
                      location = ::std::ptr::null());
 
             PointerReader {
-                marker : ::std::marker::ContravariantLifetime::<'a>,
+                marker : ::std::marker::PhantomData::<&'b ()>,
                 segment : segment,
                 pointer : ::std::mem::transmute(location),
                 nesting_limit : nesting_limit }
@@ -1860,7 +1860,7 @@ impl <'a> PointerReader<'a> {
 
     pub fn get_root_unchecked<'b>(location : *const Word) -> PointerReader<'b> {
         PointerReader {
-            marker : ::std::marker::ContravariantLifetime::<'a>,
+            marker : ::std::marker::PhantomData::<&'b ()>,
             segment : ::std::ptr::null(),
             pointer : unsafe { ::std::mem::transmute(location) },
             nesting_limit : 0x7fffffff }
@@ -1915,7 +1915,7 @@ impl <'a> PointerReader<'a> {
 }
 
 pub struct PointerBuilder<'a> {
-    marker : ::std::marker::ContravariantLifetime<'a>,
+    marker : ::std::marker::PhantomData<&'a ()>,
     segment : *mut SegmentBuilder,
     pointer : *mut WirePointer
 }
@@ -1925,7 +1925,7 @@ impl <'a> PointerBuilder<'a> {
     #[inline]
     pub fn get_root(segment : *mut SegmentBuilder, location : *mut Word) -> PointerBuilder<'a> {
         PointerBuilder {
-            marker : ::std::marker::ContravariantLifetime::<'a>,
+            marker : ::std::marker::PhantomData::<&'a ()>,
             segment : segment, pointer : unsafe { ::std::mem::transmute(location) }}
     }
 
@@ -2052,7 +2052,7 @@ impl <'a> PointerBuilder<'a> {
         unsafe {
             let segment_reader = &(*self.segment).reader;
             PointerReader {
-                marker : ::std::marker::ContravariantLifetime::<'a>,
+                marker : ::std::marker::PhantomData::<&'a ()>,
                 segment : segment_reader,
                 pointer : self.pointer as *const WirePointer,
                 nesting_limit : 0x7fffffff }
@@ -2062,7 +2062,7 @@ impl <'a> PointerBuilder<'a> {
 
 #[derive(Copy)]
 pub struct StructReader<'a> {
-    marker : ::std::marker::ContravariantLifetime<'a>,
+    marker : ::std::marker::PhantomData<&'a ()>,
     segment : *const SegmentReader,
     data : *const u8,
     pointers : *const WirePointer,
@@ -2075,7 +2075,7 @@ impl <'a> StructReader<'a>  {
 
     pub fn new_default<'b>() -> StructReader<'b> {
         StructReader {
-            marker : ::std::marker::ContravariantLifetime::<'b>,
+            marker : ::std::marker::PhantomData::<&'b ()>,
             segment : ::std::ptr::null(),
             data : ::std::ptr::null(),
             pointers : ::std::ptr::null(), data_size : 0, pointer_count : 0,
@@ -2134,7 +2134,7 @@ impl <'a> StructReader<'a>  {
     pub fn get_pointer_field(&self, ptr_index : WirePointerCount) -> PointerReader<'a> {
         if ptr_index < self.pointer_count as WirePointerCount {
             PointerReader {
-                marker : ::std::marker::ContravariantLifetime::<'a>,
+                marker : ::std::marker::PhantomData::<&'a ()>,
                 segment : self.segment,
                 pointer : unsafe { self.pointers.offset(ptr_index as isize) },
                 nesting_limit : self.nesting_limit
@@ -2165,7 +2165,7 @@ impl <'a> StructReader<'a>  {
 
 #[derive(Copy)]
 pub struct StructBuilder<'a> {
-    marker : ::std::marker::ContravariantLifetime<'a>,
+    marker : ::std::marker::PhantomData<&'a ()>,
     segment : *mut SegmentBuilder,
     data : *mut u8,
     pointers : *mut WirePointer,
@@ -2178,7 +2178,7 @@ impl <'a> StructBuilder<'a> {
         unsafe {
             let segment_reader = &(*self.segment).reader;
             StructReader {
-                marker : ::std::marker::ContravariantLifetime::<'a>,
+                marker : ::std::marker::PhantomData::<&'a ()>,
                 segment : segment_reader,
                 data : ::std::mem::transmute(self.data),
                 pointers : ::std::mem::transmute(self.pointers),
@@ -2257,7 +2257,7 @@ impl <'a> StructBuilder<'a> {
     #[inline]
     pub fn get_pointer_field(&self, ptr_index : WirePointerCount) -> PointerBuilder<'a> {
         PointerBuilder {
-            marker : ::std::marker::ContravariantLifetime::<'a>,
+            marker : ::std::marker::PhantomData::<&'a ()>,
             segment : self.segment,
             pointer : unsafe { self.pointers.offset(ptr_index as isize) }
         }
@@ -2267,7 +2267,7 @@ impl <'a> StructBuilder<'a> {
 
 #[derive(Copy)]
 pub struct ListReader<'a> {
-    marker : ::std::marker::ContravariantLifetime<'a>,
+    marker : ::std::marker::PhantomData<&'a ()>,
     segment : *const SegmentReader,
     ptr : *const u8,
     element_count : ElementCount32,
@@ -2281,7 +2281,7 @@ impl <'a> ListReader<'a> {
 
     pub fn new_default<'b>() -> ListReader<'b> {
         ListReader {
-            marker : ::std::marker::ContravariantLifetime::<'b>,
+            marker : ::std::marker::PhantomData::<&'b ()>,
             segment : ::std::ptr::null(),
             ptr : ::std::ptr::null(), element_count : 0, step: 0, struct_data_size : 0,
             struct_pointer_count : 0, nesting_limit : 0x7fffffff}
@@ -2312,7 +2312,7 @@ impl <'a> ListReader<'a> {
                );
 */
         StructReader {
-            marker : ::std::marker::ContravariantLifetime::<'a>,
+            marker : ::std::marker::PhantomData::<&'a ()>,
             segment : self.segment,
             data : struct_data,
             pointers : struct_pointers,
@@ -2325,7 +2325,7 @@ impl <'a> ListReader<'a> {
     #[inline]
     pub fn get_pointer_element(&self, index : ElementCount32) -> PointerReader<'a> {
         PointerReader {
-            marker : ::std::marker::ContravariantLifetime::<'a>,
+            marker : ::std::marker::PhantomData::<&'a ()>,
             segment : self.segment,
             pointer : unsafe {
                 ::std::mem::transmute(self.ptr.offset((index * self.step / BITS_PER_BYTE as u32) as isize))
@@ -2337,7 +2337,7 @@ impl <'a> ListReader<'a> {
 
 #[derive(Copy)]
 pub struct ListBuilder<'a> {
-    marker : ::std::marker::ContravariantLifetime<'a>,
+    marker : ::std::marker::PhantomData<&'a ()>,
     segment : *mut SegmentBuilder,
     ptr : *mut u8,
     element_count : ElementCount32,
@@ -2351,7 +2351,7 @@ impl <'a> ListBuilder<'a> {
     #[inline]
     pub fn new_default<'b>() -> ListBuilder<'b> {
         ListBuilder {
-            marker : ::std::marker::ContravariantLifetime::<'b>,
+            marker : ::std::marker::PhantomData::<&'b ()>,
             segment : ::std::ptr::null_mut(), ptr : ::std::ptr::null_mut(), element_count : 0,
             step : 0, struct_data_size : 0, struct_pointer_count : 0
         }
@@ -2368,7 +2368,7 @@ impl <'a> ListBuilder<'a> {
                 struct_data.offset(((self.struct_data_size as usize) / BITS_PER_BYTE) as isize))
         };
         StructBuilder {
-            marker : ::std::marker::ContravariantLifetime::<'a>,
+            marker : ::std::marker::PhantomData::<&'a ()>,
             segment : self.segment,
             data : struct_data,
             pointers : struct_pointers,
@@ -2380,7 +2380,7 @@ impl <'a> ListBuilder<'a> {
     #[inline]
     pub fn get_pointer_element(&self, index : ElementCount32) -> PointerBuilder<'a> {
         PointerBuilder {
-            marker : ::std::marker::ContravariantLifetime::<'a>,
+            marker : ::std::marker::PhantomData::<&'a ()>,
             segment : self.segment,
             pointer : unsafe {
                 ::std::mem::transmute(self.ptr.offset((index * self.step / BITS_PER_BYTE as u32) as isize))

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -147,7 +147,7 @@ pub fn write_message<T : ::std::old_io::Writer, U : MessageBuilder>(
     message : &U) -> ::std::old_io::IoResult<()> {
 
     try!(message.get_segments_for_output(
-        |segments| {
+        |segments| -> ::std::old_io::IoResult<()> {
 
             let table_size : usize = (segments.len() + 2) & (!1);
 

--- a/src/serialize_packed.rs
+++ b/src/serialize_packed.rs
@@ -23,7 +23,7 @@ use io;
 use message::*;
 use serialize;
 
-trait PtrUsize<T> {
+trait PtrUsize<T>: ::std::marker::PhantomFn<T> {
     fn as_usize(self) -> usize;
 }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -40,6 +40,7 @@ impl <'a> ::traits::FromPointerReader<'a> for Reader<'a> {
 }
 
 pub struct Builder<'a> {
+    marker : ::std::marker::PhantomData<&'a ()>,
     ptr : *mut u8,
     len : usize,
 }
@@ -47,7 +48,7 @@ pub struct Builder<'a> {
 impl <'a> Builder <'a> {
 
     pub fn new<'b>(p : *mut u8, len : u32) -> Builder<'b> {
-        Builder { ptr : p, len : len as usize}
+        Builder { ptr : p, len : len as usize, marker : ::std::marker::PhantomData::<&'b ()> }
     }
 
     pub fn as_mut_bytes(self) -> &'a mut [u8] {
@@ -59,7 +60,7 @@ impl <'a> Builder <'a> {
     }
 
     pub fn borrow<'b>(&'b mut self) -> Builder<'b> {
-        Builder { ptr : self.ptr, len : self.len }
+        Builder { ptr : self.ptr, len : self.len, marker : ::std::marker::PhantomData::<&'b ()> }
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -51,7 +51,7 @@ pub trait FromPointerBuilderRefDefault<'a> {
     fn get_from_pointer(builder : PointerBuilder<'a>, default_value : *const Word) -> Self;
 }
 
-pub trait SetPointerBuilder<To> {
+pub trait SetPointerBuilder<To>: ::std::marker::PhantomFn<To> {
     fn set_pointer_builder<'a>(PointerBuilder<'a>, Self);
 }
 
@@ -75,6 +75,7 @@ pub trait IndexMove<I, T> {
 }
 
 pub struct ListIter<T, U> {
+    marker : ::std::marker::PhantomData<U>,
     list : T,
     index : u32,
     size : u32,
@@ -82,7 +83,7 @@ pub struct ListIter<T, U> {
 
 impl <T, U> ListIter<T, U> {
     pub fn new(list : T, size : u32) -> ListIter<T, U> {
-        ListIter { list : list, index : 0, size : size }
+        ListIter { list : list, index : 0, size : size, marker : ::std::marker::PhantomData }
     }
 }
 


### PR DESCRIPTION
ContravariantLifetime was deprecated and there were a bunch of unused type parameters that needed markers.  Tried to match style as best as possible; let me know if it needs tweaking.