### PR TITLE
Move to &mut s[..] syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ impl Word {
         let mut result : ::std::vec::Vec<Word> = ::std::vec::Vec::with_capacity(length);
         unsafe {
             result.set_len(length);
-            let p : *mut u8 = ::std::mem::transmute(result.as_mut_slice().as_mut_ptr());
+            let p : *mut u8 = ::std::mem::transmute(&mut result[..].as_mut_ptr());
             ::std::ptr::write_bytes(p, 0u8, length * ::std::mem::size_of::<Word>());
         }
         return result;

--- a/src/private/arena.rs
+++ b/src/private/arena.rs
@@ -330,8 +330,8 @@ impl BuilderArena {
                 let len = self.more_segments.len();
                 if len == 0 { 1 }
                 else {
-                    let result_ptr : *mut SegmentBuilder = &mut *self.more_segments.as_mut_slice()[len-1];
-                    match self.more_segments.as_mut_slice()[len - 1].allocate(amount) {
+                    let result_ptr : *mut SegmentBuilder = &mut *self.more_segments[len-1];
+                    match self.more_segments[len - 1].allocate(amount) {
                         Some(result) => { return (result_ptr, result) }
                         None => { len + 1 }
                     }
@@ -352,7 +352,7 @@ impl BuilderArena {
         if id == 0 {
             Ok(&mut self.segment0)
         } else if ((id - 1) as usize) < self.more_segments.len() {
-            Ok(&mut *self.more_segments.as_mut_slice()[(id - 1) as usize])
+            Ok(&mut *self.more_segments[(id - 1) as usize])
         } else {
             Err(Error::new_decode_error("Invalid segment id.", Some(format!("{}", id))))
         }
@@ -406,7 +406,7 @@ impl ArenaPtr {
                     if id == 0 {
                         Ok(&(*builder).segment0.reader)
                     } else if ((id - 1) as usize) < (*builder).more_segments.len() {
-                        Ok(&(*builder).more_segments.as_mut_slice()[(id - 1) as usize].reader)
+                        Ok(&(*builder).more_segments[(id - 1) as usize].reader)
                     } else {
                         Err(Error::new_decode_error("Invalid segment id.", Some(format!("{}", id))))
                     }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -96,7 +96,7 @@ pub fn new_reader<U : InputStream>(
     let buf_len = total_words as usize * BYTES_PER_WORD;
 
     unsafe {
-        let ptr : *mut u8 = ::std::mem::transmute(owned_space.as_mut_slice().as_mut_ptr());
+        let ptr : *mut u8 = ::std::mem::transmute(&mut owned_space[..].as_mut_ptr());
         let buf = ::std::slice::from_raw_parts_mut::<u8>(ptr, buf_len);
         try!(input_stream.read_exact(buf));
     }
@@ -142,14 +142,14 @@ pub fn write_message<T : OutputStream, U : MessageBuilder>(
     let mut table : Vec<WireValue<u32>> = Vec::with_capacity(table_size);
     unsafe { table.set_len(table_size) }
 
-    table.as_mut_slice()[0].set((segments.len() - 1) as u32);
+    &mut table[..][0].set((segments.len() - 1) as u32);
 
     for i in 0..segments.len() {
-        table.as_mut_slice()[i + 1].set(segments[i].len() as u32);
+        &mut table[..][i + 1].set(segments[i].len() as u32);
     }
     if segments.len() % 2 == 0 {
         // Set padding.
-        table.as_mut_slice()[segments.len() + 1].set( 0 );
+        &mut table[..][segments.len() + 1].set( 0 );
     }
 
     unsafe {

--- a/src/serialize_packed.rs
+++ b/src/serialize_packed.rs
@@ -422,7 +422,7 @@ mod tests {
 
         let mut bytes : std::vec::Vec<u8> = ::std::iter::repeat(0u8).take(packed.len()).collect();
         {
-            let mut writer = ArrayOutputStream::new(bytes.as_mut_slice());
+            let mut writer = ArrayOutputStream::new(&mut bytes[..]);
             let mut packed_output_stream = PackedOutputStream {inner : &mut writer};
             packed_output_stream.write(unpacked).unwrap();
         }
@@ -437,7 +437,7 @@ mod tests {
 
 
         let mut bytes : std::vec::Vec<u8> = ::std::iter::repeat(0u8).take(unpacked.len()).collect();
-        packed_input_stream.read_exact(bytes.as_mut_slice()).unwrap();
+        packed_input_stream.read_exact(&mut bytes[..]).unwrap();
 
         //    assert!(packed_input_stream.eof());
         assert_eq!(bytes, unpacked);


### PR DESCRIPTION
The newest `rustc` considers this an error without a feature flag... Please double check my changes as there are modifications to `unsafe` code which I am not certain of.