### PR TITLE
Implement compute_serialized_size_in_words

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -167,3 +167,16 @@ pub fn write_message<T : OutputStream, U : MessageBuilder>(
     }
     output_stream.flush()
 }
+
+pub fn compute_serialized_size_in_words<U : MessageBuilder>(message: &mut U) -> usize {
+    let segments = message.get_segments_for_output();
+
+    // Table size
+    let mut size = (segments.len() / 2) + 1;
+
+    for segment in segments {
+        size += segment.len();
+    }
+
+    size
+}


### PR DESCRIPTION
This new function allows to compute the size a message will have when serialized.

It can be useful when doing asynchronous IO, where it might be needed to make sure that the entire message has arrived before starting to process it.

(Inspired from the C++ version computeSerializedSizeInWords)