### PR TITLE
Rework traits HasTypeId and HasStructSize

### DIFF
--- a/src/struct_list.rs
+++ b/src/struct_list.rs
@@ -106,13 +106,13 @@ impl <'a, T : FromStructBuilder<'a> + HasStructSize> FromPointerBuilder<'a> for 
     fn init_pointer(builder : PointerBuilder<'a>, size : u32) -> Builder<'a, T> {
         Builder {
             marker : ::std::marker::PhantomData,
-            builder : builder.init_struct_list(size, HasStructSize::struct_size(None::<T>))
+            builder : builder.init_struct_list(size, <T as HasStructSize>::struct_size())
         }
     }
     fn get_from_pointer(builder : PointerBuilder<'a>) -> Result<Builder<'a, T>> {
         Ok(Builder {
             marker : ::std::marker::PhantomData,
-            builder : try!(builder.get_struct_list(HasStructSize::struct_size(None::<T>), ::std::ptr::null()))
+            builder : try!(builder.get_struct_list(<T as HasStructSize>::struct_size(), ::std::ptr::null()))
         })
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -27,7 +27,7 @@ pub trait FromStructReader<'a> {
 }
 
 pub trait HasStructSize {
-    fn struct_size(unused_self : Option<Self>) -> StructSize;
+    fn struct_size() -> StructSize;
 }
 
 pub trait FromStructBuilder<'a> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -56,7 +56,7 @@ pub trait SetPointerBuilder<To> {
 }
 
 pub trait HasTypeId {
-    fn type_id(unused_self : Option<Self>) -> u64;
+    fn type_id() -> u64;
 }
 
 pub trait CastableTo<T> {


### PR DESCRIPTION
UFCS has made possible to unambiguously call a "static" method on a trait without `Self` appearing in the parameters.

This patch replaces the old hack of putting a parameter `Option<Self>` and use the new notation instead.

A pull request for changing generated code will follow.