### PR TITLE
write_message should take a const message

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -155,11 +155,11 @@ where R: Read {
 ///
 /// For optimal performance, `write` should be a buffered writer. `flush` will not be called on
 /// the writer.
-pub fn write_message<W, M>(write: &mut W, message: &mut M) -> ::std::io::Result<()>
+pub fn write_message<W, M>(write: &mut W, message: &M) -> ::std::io::Result<()>
 where W: Write, M: MessageBuilder {
     let segments = message.get_segments_for_output();
-    try!(write_segment_table(write, segments));
-    write_segments(write, segments)
+    try!(write_segment_table(write, &segments));
+    write_segments(write, &segments)
 }
 
 /// Writes a segment table to `write`.
@@ -203,7 +203,7 @@ where W: Write {
     Ok(())
 }
 
-pub fn compute_serialized_size_in_words<U : MessageBuilder>(message: &mut U) -> usize {
+pub fn compute_serialized_size_in_words<U : MessageBuilder>(message: &U) -> usize {
     let segments = message.get_segments_for_output();
 
     // Table size

--- a/src/serialize_packed.rs
+++ b/src/serialize_packed.rs
@@ -356,9 +356,8 @@ impl <W> Write for PackedWrite<W> where W: Write {
 }
 
 /// Writes a packed message to a stream.
-pub fn write_message<W, M>(write: &mut W, message : &mut M) -> io::Result<()>
-    where W: Write, M: MessageBuilder
-{
+pub fn write_message<W, M>(write: &mut W, message: &M) -> io::Result<()>
+where W: Write, M: MessageBuilder {
     let mut packed_write = PackedWrite { inner: write };
     serialize::write_message(&mut packed_write, message)
 }


### PR DESCRIPTION
This makes it possible to write a message from multiple contexts (threads, callbacks) without a lock.