### PR TITLE
Added SetPointerBuilder to Owned<'a>::Reader to maximise usefulness of Owned.

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -50,7 +50,7 @@ pub trait FromPointerReader<'a> {
 /// as a type parameter, e.g. for a generic container that owns a Cap'n Proto message
 /// of type `T: for<'a> capnp::traits::Owned<'a>`.
 pub trait Owned<'a> {
-    type Reader: FromPointerReader<'a>;
+    type Reader: FromPointerReader<'a> + SetPointerBuilder<Self::Builder>;
     type Builder: FromPointerBuilder<'a>;
     type Pipeline;
 }


### PR DESCRIPTION
I've modified Owned<'a> so that Reader is constrainted with SetPointerBuilder. This way I can use an object X of type T::Builder with X.set_root(Y.get_root::<T::Reader>());