### PR TITLE
Add optional (off by default) quickcheck feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/lib.rs"
 
 [dependencies]
 byteorder = "0.3.13"
+quickcheck = { version = "0.2", optional = true }
 
 [dev-dependencies]
-quickcheck = "*"
+quickcheck = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 
 extern crate byteorder;
 
-#[cfg(test)]
+#[cfg(any(feature="quickcheck", test))]
 extern crate quickcheck;
 
 pub mod any_pointer;
@@ -103,13 +103,10 @@ impl Word {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(feature="quickcheck", test))]
 impl quickcheck::Arbitrary for Word {
     fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Word {
         Word(quickcheck::Arbitrary::arbitrary(g))
-    }
-    fn shrink(&self) -> Box<Iterator<Item=Word>+'static> {
-        Box::new(quickcheck::Arbitrary::shrink(&self.0).map(|value| Word(value)))
     }
 }
 


### PR DESCRIPTION
Allows other crates to opt-in to having a quickcheck::Arbitrary impl for Word.