### PR TITLE
bump byteorder version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "capnp"
 path = "src/lib.rs"
 
 [dependencies]
-byteorder = "0.3.13"
+byteorder = "0.4"
 quickcheck = { version = "0.2", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
The breaking changes in `byteorder` were not to APIs that `capnp` uses.