### PR TITLE
Implement DoubleEndedIter for ListIter

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -149,3 +149,14 @@ impl <U, T: IndexMove<u32, U>> ::std::iter::ExactSizeIterator for ListIter<T, U>
         self.size as usize
     }
 }
+
+impl <U, T: IndexMove<u32, U>> ::std::iter::DoubleEndedIterator for ListIter<T, U>{
+    fn next_back(&mut self) -> ::std::option::Option<U> {
+        if self.size > self.index {
+            self.size -= 1;
+            Some(self.list.index_move(self.size))
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
This makes it convenient to walk backwards along a list in-place.

I haven't really tested this properly, but it might be a while before I get to that, so I'm submitting this now as the code's pretty simple anyway.