### PR TITLE
remove dependency on Rc

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -150,8 +150,8 @@ impl <S> Reader<S> where S: ReaderSegments {
 
         let pointer_reader = try!(layout::PointerReader::get_root(
             &self.arena, 0, segment_start, self.nesting_limit));
-        let read_head = ::std::rc::Rc::new(::std::cell::Cell::new(
-            unsafe {segment_start.offset(1)}));
+        let read_head = ::std::cell::Cell::new(
+            unsafe {segment_start.offset(1)});
         let root_is_canonical = try!(pointer_reader.is_canonical(&read_head));
         let all_words_consumed =
             (read_head.get() as usize - segment_start as usize) / BYTES_PER_WORD == seg_len as usize;

--- a/src/private/layout.rs
+++ b/src/private/layout.rs
@@ -21,7 +21,6 @@
 
 use std::mem;
 use std::ptr;
-use std::rc::Rc;
 use std::cell::Cell;
 
 use data;
@@ -2390,7 +2389,7 @@ impl <'a> PointerReader<'a> {
         }
     }
 
-    pub fn is_canonical(&self, read_head: &Rc<Cell<*const Word>>) -> Result<bool> {
+    pub fn is_canonical(&self, read_head: &Cell<*const Word>) -> Result<bool> {
         match try!(self.get_pointer_type()) {
             PointerType::Null => Ok(true),
             PointerType::Struct => {
@@ -2400,8 +2399,8 @@ impl <'a> PointerReader<'a> {
                 if st.get_data_section_size() == 0 && st.get_pointer_section_size() == 0 {
                     Ok(self.pointer as *const _ == st.get_location())
                 } else {
-                    let ptr_head = read_head.clone();
-                    let result = try!(st.is_canonical(read_head, &ptr_head, &mut data_trunc, &mut ptr_trunc));
+                    let ptr_head = read_head;
+                    let result = try!(st.is_canonical(read_head, ptr_head, &mut data_trunc, &mut ptr_trunc));
                     Ok(result && data_trunc && ptr_trunc)
                 }
             }
@@ -2733,8 +2732,8 @@ impl <'a> StructReader<'a> {
 
     pub fn is_canonical(
         &self,
-        read_head: &Rc<Cell<*const Word>>,
-        ptr_head: &Rc<Cell<*const Word>>,
+        read_head: &Cell<*const Word>,
+        ptr_head: &Cell<*const Word>,
         data_trunc: &mut bool,
         ptr_trunc: &mut bool,
     )
@@ -2957,7 +2956,7 @@ impl <'a> ListReader<'a> {
 
     pub fn is_canonical(
         &self,
-        read_head: &Rc<Cell<*const Word>>,
+        read_head: &Cell<*const Word>,
         reff: *const WirePointer)
         -> Result<bool>
     {
@@ -2981,7 +2980,7 @@ impl <'a> ListReader<'a> {
                 }
                 let list_end =
                     unsafe { read_head.get().offset((self.element_count * struct_size) as isize) };
-                let pointer_head = Rc::new(Cell::new(list_end));
+                let pointer_head = Cell::new(list_end);
                 let mut list_data_trunc = false;
                 let mut list_ptr_trunc = false;
                 for idx in 0..self.element_count {


### PR DESCRIPTION
Thre is no need for a `Rc` in this function (and this function is the only one that uses `Rc`), as the object is created in a function and the references are just passed to recursive function calls. The Rc gets you no safety and only eats performance.